### PR TITLE
Remove type declaration from PDO::prepare() second arg.

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -882,7 +882,7 @@ class PDO  {
 	 * Emulated prepared statements does not communicate with the database server
 	 * so <b>PDO::prepare</b> does not check the statement.
 	 */
-	public function prepare ($statement, array $driver_options = array()) {}
+	public function prepare ($statement, $driver_options = array()) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>


### PR DESCRIPTION
```
$ php -v
PHP 7.4.8 (cli) (built: Jul 29 2020 17:49:07) ( ZTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Xdebug v2.9.6, Copyright (c) 2002-2020, by Derick Rethans
```
```
$ php -a
Interactive mode enabled

<?php

class MyPDO extends PDO {
  public function prepare($statement, array $driver_options = array()){}
  public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = array()){}
}
PHP Warning:  Declaration of MyPDO::prepare($statement, array $driver_options = Array) should be compatible with PDO::prepare($statement, $options = NULL) in Standard input code on line 4

Warning: Declaration of MyPDO::prepare($statement, array $driver_options = Array) should be compatible with PDO::prepare($statement, $options = NULL) in Standard input code on line 4
```
```
$ php -a
Interactive mode enabled

<?php

class MyPDO extends PDO {
  public function prepare($statement, $driver_options = array()){}
  public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = array()){}
}
```